### PR TITLE
Ignore ESC and return focus on fullscreen. Fix #85

### DIFF
--- a/src/app/mosh_window.js
+++ b/src/app/mosh_window.js
@@ -40,6 +40,20 @@ function execMosh() {
     terminal.runCommandClass(mosh.CommandInstance, window.args);
   };
 
+  // Don't exit fullscreen with ESC
+  terminal.document_.onkeyup = function(e) {
+    if (e.keyCode == 27) e.preventDefault()
+  };
+
+  // Workaround to return focus to terminal on fullscreen
+  // See https://code.google.com/p/chromium/issues/detail?id=402340
+  var appWindow = chrome.app.window.current();
+  appWindow.onFullscreened.addListener(function () {
+    appWindow.hide();
+    appWindow.show();
+    terminal.focus();
+  });
+
   document.title += ' - ' + window.args['addr'];
 
   // Useful for console debugging.

--- a/src/manifest.json.template
+++ b/src/manifest.json.template
@@ -21,7 +21,8 @@
     "clipboardWrite",
     "contextMenus",
     "notifications",
-    "storage"
+    "storage",
+    "app.window.fullscreen.overrideEsc"
   ],
   "icons": {
     "128": "laptop_terminal.png"


### PR DESCRIPTION
Got obsessed with this and figured out some things. 

Aside from the preventDefault on ESC, I included a real hacky workaround to deal with https://code.google.com/p/chromium/issues/detail?id=402340. Notice that we have to hide, then show the app window. Hope that code becomes unnecessary soon.