### PR TITLE
Add configuration option for Mosh escape key

### DIFF
--- a/mosh_app/mosh_client.html
+++ b/mosh_app/mosh_client.html
@@ -74,8 +74,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <td><input id="server-command" type="text" disabled placeholder="default"></td>
           </tr>
           <tr id="mosh-escape-key-row">
-            <td>Mosh escape key (default: <code>^</code>)</td>
-            <td><input id="mosh-escape-key" type="text" disabled placeholder="default"></td>
+            <td>Mosh escape key:</td>
+            <td>
+              <select name="mosh-escape-key">
+                <!-- Populated in window.onload in mosh_client.js. -->
+              </select>
+            </td>
           </tr>
         </table>
         <input id="connect" type="submit" value="Connect">

--- a/mosh_app/mosh_client.html
+++ b/mosh_app/mosh_client.html
@@ -73,6 +73,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <td>Mosh server command:</td>
             <td><input id="server-command" type="text" disabled placeholder="default"></td>
           </tr>
+          <tr id="mosh-escape-key-row">
+            <td>Mosh escape key (default: <code>^</code>)</td>
+            <td><input id="mosh-escape-key" type="text" disabled placeholder="default"></td>
+          </tr>
         </table>
         <input id="connect" type="submit" value="Connect">
       </form>

--- a/mosh_app/mosh_client.js
+++ b/mosh_app/mosh_client.js
@@ -59,15 +59,15 @@ window.onload = function() {
 
   // Add drop-down menu for MOSH_ESCAPE_KEY, listing all ASCII characters from
   // 0x01 to 0x7F.
-  for (var c = 1; c <= 127; ++c) {
-    // For c < 32 and c == 127, see
+  for (var c = 0x01; c <= 0x7F; ++c) {
+    // For c < 0x20 and c == 0x7F, see
     // https://en.wikipedia.org/wiki/C0_and_C1_control_codes#C0_.28ASCII_and_derivatives.29
     var keyName;
-    if (c < 32) {
-      keyName = "Ctrl+" + String.fromCharCode(64 + c);
-    } else if (c == 32) {
+    if (c < 0x20) {
+      keyName = "Ctrl+" + String.fromCharCode(0x40 + c);
+    } else if (c == 0x20) {
       keyName = "SPACE";
-    } else if (c < 127) {
+    } else if (c < 0x7F) {
       keyName = String.fromCharCode(c);
     } else {
       keyName = "Ctrl+?";

--- a/mosh_app/mosh_client.js
+++ b/mosh_app/mosh_client.js
@@ -108,6 +108,7 @@ var kSyncFieldNames = [
   'user',
   'remote-command',
   'server-command',
+  'mosh-escape-key',
 ];
 
 function loadFields() {
@@ -157,6 +158,7 @@ function onConnectClick(e) {
   args['key'] = form['key'].value;
   args['remote-command'] = form['remote-command'].value;
   args['server-command'] = form['server-command'].value;
+  args['mosh-escape-key'] = form['mosh-escape-key'].value;
   for (var i = 0; i < form['mode'].length; ++i) {
     if (form['mode'][i].checked) {
       args['mode'] = form['mode'][i].value;
@@ -203,6 +205,7 @@ function updateMode(e) {
   var keyRow = document.querySelector('#key-row');
   var remoteCommandRow = document.querySelector('#remote-command-row');
   var serverCommandRow = document.querySelector('#server-command-row');
+  var moshEscapeKeyRow = document.querySelector('#mosh-escape-key-row');
 
   if (sshModeButton.checked) {
     if (sshPortField.value === "") {
@@ -214,6 +217,7 @@ function updateMode(e) {
     keyRow.hidden = true;
     remoteCommandRow.hidden = false;
     serverCommandRow.hidden = false;
+    moshEscapeKeyRow.hidden = false;
   } else {
     if (moshPortField.value === "") {
       moshPortField.value = kMoshDefaultPort;
@@ -224,6 +228,7 @@ function updateMode(e) {
     keyRow.hidden = false;
     remoteCommandRow.hidden = true;
     serverCommandRow.hidden = true;
+    moshEscapeKeyRow.hidden = false;
   }
 }
 

--- a/mosh_app/mosh_client.js
+++ b/mosh_app/mosh_client.js
@@ -217,7 +217,6 @@ function updateMode(e) {
     keyRow.hidden = true;
     remoteCommandRow.hidden = false;
     serverCommandRow.hidden = false;
-    moshEscapeKeyRow.hidden = false;
   } else {
     if (moshPortField.value === "") {
       moshPortField.value = kMoshDefaultPort;
@@ -228,7 +227,6 @@ function updateMode(e) {
     keyRow.hidden = false;
     remoteCommandRow.hidden = true;
     serverCommandRow.hidden = true;
-    moshEscapeKeyRow.hidden = false;
   }
 }
 

--- a/mosh_app/mosh_client.js
+++ b/mosh_app/mosh_client.js
@@ -58,7 +58,9 @@ window.onload = function() {
   form.onsubmit = function() { return false; };
 
   // Add drop-down menu for MOSH_ESCAPE_KEY, listing all ASCII characters from
-  // 0x01 to 0x7F.
+  // 0x01 to 0x7F, as well an initial entry "default" to not pass
+  // MOSH_ESCAPE_KEY at all.
+  form['mosh-escape-key'].add(new Option("default", "", true));
   for (var c = 0x01; c <= 0x7F; ++c) {
     // For c < 0x20 and c == 0x7F, see
     // https://en.wikipedia.org/wiki/C0_and_C1_control_codes#C0_.28ASCII_and_derivatives.29
@@ -74,10 +76,9 @@ window.onload = function() {
     }
     form['mosh-escape-key'].add(new Option(
         keyName,
-        // value element of <option> element must be HTML-encoded.
+        // Value element of <option> element must be HTML-encoded.
         "&#x" + c.toString(16),
-        // Make Ctrl-^ (0x1E) the default MOSH_ESCAPE_KEY.
-        c == 0x1E));
+        false));
   }
 
   migrateSettings(function() {
@@ -187,7 +188,10 @@ function onConnectClick(e) {
   args['key'] = form['key'].value;
   args['remote-command'] = form['remote-command'].value;
   args['server-command'] = form['server-command'].value;
-  args['mosh-escape-key'] = decodeHtml(form['mosh-escape-key'].value);
+  var decodedMoshEscapeKey = decodeHtml(form['mosh-escape-key'].value);
+  if (decodedMoshEscapeKey !== "") {
+    args['mosh-escape-key'] = decodedMoshEscapeKey;
+  }
   for (var i = 0; i < form['mode'].length; ++i) {
     if (form['mode'][i].checked) {
       args['mode'] = form['mode'][i].value;

--- a/mosh_app/mosh_client.js
+++ b/mosh_app/mosh_client.js
@@ -57,6 +57,29 @@ window.onload = function() {
   var form = document.querySelector('#args');
   form.onsubmit = function() { return false; };
 
+  // Add drop-down menu for MOSH_ESCAPE_KEY, listing all ASCII characters from
+  // 0x01 to 0x7F.
+  for (var c = 1; c <= 127; ++c) {
+    // For c < 32 and c == 127, see
+    // https://en.wikipedia.org/wiki/C0_and_C1_control_codes#C0_.28ASCII_and_derivatives.29
+    var keyName;
+    if (c < 32) {
+      keyName = "Ctrl+" + String.fromCharCode(64 + c);
+    } else if (c == 32) {
+      keyName = "SPACE";
+    } else if (c < 127) {
+      keyName = String.fromCharCode(c);
+    } else {
+      keyName = "Ctrl+?";
+    }
+    form['mosh-escape-key'].add(new Option(
+        keyName,
+        // value element of <option> element must be HTML-encoded.
+        "&#x" + c.toString(16),
+        // Make Ctrl-^ (0x1E) the default MOSH_ESCAPE_KEY.
+        c == 0x1E));
+  }
+
   migrateSettings(function() {
     loadFields();
     updateMode();
@@ -141,6 +164,12 @@ function saveFields() {
   });
 }
 
+function decodeHtml(html) {
+    var txt = document.createElement("textarea");
+    txt.innerHTML = html;
+    return txt.value;
+}
+
 function onConnectClick(e) {
   saveFields();
   var args = {}
@@ -158,7 +187,7 @@ function onConnectClick(e) {
   args['key'] = form['key'].value;
   args['remote-command'] = form['remote-command'].value;
   args['server-command'] = form['server-command'].value;
-  args['mosh-escape-key'] = form['mosh-escape-key'].value;
+  args['mosh-escape-key'] = decodeHtml(form['mosh-escape-key'].value);
   for (var i = 0; i < form['mode'].length; ++i) {
     if (form['mode'][i].checked) {
       args['mode'] = form['mode'][i].value;

--- a/mosh_nacl/mosh_nacl.cc
+++ b/mosh_nacl/mosh_nacl.cc
@@ -458,6 +458,7 @@ bool MoshClientInstance::Init(
   const char *secret = nullptr;
   string addr;
   string family;
+  string mosh_escape_key;
   for (int i = 0; i < argc; ++i) {
     string name = argn[i];
     int len = strlen(argv[i]) + 1;
@@ -482,6 +483,8 @@ bool MoshClientInstance::Init(
       ssh_login_.set_server_command(argv[i]);
     } else if (name == "use-agent") {
       ssh_login_.set_use_agent(string(argv[i]) == "true");
+    } else if (name == "mosh-escape-key") {
+      mosh_escape_key = argv[i];
     }
   }
 
@@ -497,6 +500,10 @@ bool MoshClientInstance::Init(
     }
   } else {
     setenv("MOSH_KEY", secret, 1);
+  }
+
+  if (!mosh_escape_key.empty()) {
+    setenv("MOSH_ESCAPE_KEY", mosh_escape_key.c_str(), 1);
   }
 
   PP_HostResolver_Hint hint;


### PR DESCRIPTION
Allow user to set the [`MOSH_ESCAPE_KEY`](https://github.com/mobile-shell/mosh/blob/b742e958b6ae7185f557263e4b81db0e1038b882/man/mosh.1#L217) environment variable.