### PR TITLE
Add support for gnubbyd extension on non-ChromeOS devices.

### DIFF
--- a/mosh_app/mosh_window.js
+++ b/mosh_app/mosh_window.js
@@ -76,7 +76,9 @@ mosh.CommandInstance = function(argv) {
 
   // App ID of an SSH agent.
   // TODO: Make this a user setting.
-  this.agentAppID_ = 'beknehfpfkghjoafdifaflglpjkojoco';
+  this.agentAppID_ = hterm.os == 'cros' ?
+      'beknehfpfkghjoafdifaflglpjkojoco' :  // Chrome app
+      'lkjlajklkdhaneeelolkfgbpikkgnkpk';   // Chrome extension
 };
 
 mosh.CommandInstance.prototype.run = function() {


### PR DESCRIPTION
Non-ChromeOS devices are now using the gnubbyd extension to communicate with smart cards instead of the Chrome app.

This doesn't work for supporting yubikeys in the standalone NW.js Windows app, but it at least re-enables the Chrome app while that continues working.