### PR TITLE
set HTML/JS runtime encoding to UTF-8

### DIFF
--- a/mosh_app/mosh_client.html
+++ b/mosh_app/mosh_client.html
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <head>
+  <meta charset="utf-8"/>
   <title>Mosh Sessions</title>
   <script src="mosh_client.js" type="text/javascript"></script>
   <script src="mosh_version.js" type="text/javascript"></script>

--- a/mosh_app/mosh_prefs.html
+++ b/mosh_app/mosh_prefs.html
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <head>
+  <meta charset="utf-8"/>
   <title>Mosh Preferences</title>
   <script src="hterm_all.js" type="text/javascript"></script>
   <script src="nassh_workarounds.js"></script>

--- a/mosh_app/mosh_window.html
+++ b/mosh_app/mosh_window.html
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <head>
+  <meta charset="utf-8"/>
   <title>Mosh</title>
   <script src="mosh_manifest.js" type="text/javascript"></script>
   <script src="mosh_window.js" type="text/javascript"></script>

--- a/mosh_app/ssh_key.html
+++ b/mosh_app/ssh_key.html
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <head>
+  <meta charset="utf-8"/>
   <title>Mosh ssh key</title>
   <script src="ssh_key.js" type="text/javascript"></script>
 </head>


### PR DESCRIPTION
This can subtly affect how Chrome interprets embedded strings.
The current code in here shouldn't be affected as it's all ASCII,
but Chrome warns about the implicit encoding detection and uses
ISO-8859-1 instead.