### PR TITLE
fix minor crash with term-init-string prefs

### DIFF
--- a/mosh_app/mosh_window.js
+++ b/mosh_app/mosh_window.js
@@ -108,7 +108,7 @@ mosh.CommandInstance.prototype.run = function() {
 
   // Output special text (e.g., ANSI escape sequences) if desired.
   chrome.storage.sync.get('term_init_string', function(o) {
-    if (o != null) {
+    if (o && o['term_init_string']) {
       window.mosh_client_.io.print(o['term_init_string']);
     }
   });


### PR DESCRIPTION
The storage call here will return an empty object when the key
isn't found which causes this code to pass undefined down to the
terminal print layers (which then crashes).  It doesn't affect
the running of the app because this is a callback func in its
own execution scope, but it does clutter up the console log.