### PR TITLE
fix transmitting non-ASCII data

### DIFF
--- a/mosh_app/mosh_window.js
+++ b/mosh_app/mosh_window.js
@@ -231,13 +231,8 @@ mosh.CommandInstance.prototype.onMessage_ = function(e) {
 
 mosh.CommandInstance.prototype.sendKeyboard_ = function(string) {
   if (this.running_) {
-    // Convert this to an array of codepoints to avoid any Unicode shenanigans,
-    // which can interfere with terminal escape sequences.
-    var codePoints = [];
-    for (var i = 0; i < string.length; i++) {
-      codePoints.push(string.codePointAt(i));
-    }
-    this.moshNaCl_.postMessage({'keyboard': codePoints});
+    const te = new TextEncoder();
+    this.moshNaCl_.postMessage({'keyboard': Array.from(te.encode(string))});
   } else if (string == 'x') {
     window.close();
   }


### PR DESCRIPTION
Transmit UTF-8 data to the plugin rather than codepoints as the client
seems to be expecting it that way.

This fixes pasting of non-ASCII data into the terminal.